### PR TITLE
[#159751472] make scrolling less janky when users scroll quickly

### DIFF
--- a/src/MessageContainer.js
+++ b/src/MessageContainer.js
@@ -103,7 +103,7 @@ export default class MessageContainer extends React.PureComponent {
           automaticallyAdjustContentInsets={false}
           initialNumToRender={MAX_RENDER_ITEM}
           maxToRenderPerBatch={MAX_RENDER_ITEM}
-          windowSize={6}
+          windowSize={12}
           updateCellsBatchingPeriod={500}
           removeClippedSubviews
           inverted={this.props.inverted}


### PR DESCRIPTION
There were a lot of changes I tried to put in here in an attempt to improve efficiency based upon the research...
I tried to remove some unnecessary timeouts, give the flatlist a key, implement a `shouldComponentUpdate` for it, add additional constraints for rendering the list itself, fiddle around with the flatlist props... All of these things had dubious results at best, and actually slowed things down (or made it look really janky) at worse.  The one thing which did do something useful though, was upping the windowSize, so that users who scroll quickly won't see the list try to rerender itself if they repeatedly scroll from top to bottom.

The main slowdown is coming from the ChatBubble component, which apparently has a bit of downtime before it even calls the other render methods