### PR TITLE
Bug dont avoid when pdm open

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -287,7 +287,6 @@ class GiftedChat extends React.Component {
   }
 
   onKeyboardWillHide() {
-    console.log('gifted chat keyboard will hide');
     if (this.props.isPDMOpen) {
       return;
     }

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -266,6 +266,10 @@ class GiftedChat extends React.Component {
   }
 
   onKeyboardWillShow(e) {
+    if (this.props.isPDMOpen) {
+      return;
+    }
+
     this.setIsTypingDisabled(true);
     this.setKeyboardHeight(e.endCoordinates ? e.endCoordinates.height : e.end.height);
     this.setBottomOffset(this.props.bottomOffset);
@@ -283,6 +287,11 @@ class GiftedChat extends React.Component {
   }
 
   onKeyboardWillHide() {
+    console.log('gifted chat keyboard will hide');
+    if (this.props.isPDMOpen) {
+      return;
+    }
+
     this.setIsTypingDisabled(true);
     this.setKeyboardHeight(0);
     this.setBottomOffset(0);
@@ -300,6 +309,10 @@ class GiftedChat extends React.Component {
   }
 
   onKeyboardDidShow(e) {
+    if (this.props.isPDMOpen) {
+      return;
+    }
+
     if (Platform.OS === 'android') {
       this.onKeyboardWillShow(e);
     }
@@ -307,6 +320,10 @@ class GiftedChat extends React.Component {
   }
 
   onKeyboardDidHide(e) {
+    if (this.props.isPDMOpen) {
+      return;
+    }
+
     if (Platform.OS === 'android') {
       this.onKeyboardWillHide(e);
     }
@@ -459,7 +476,7 @@ class GiftedChat extends React.Component {
     } else {
       this.setState({ mainViewLayout: layout });
     }
-    
+
     if (this.getIsFirstLayout() === true) {
       this.setIsFirstLayout(false);
     }
@@ -645,6 +662,7 @@ GiftedChat.propTypes = {
   forceGetKeyboardHeight: PropTypes.bool,
   inverted: PropTypes.bool,
   textInputProps: PropTypes.object,
+  isPDMOpen: PropTypes.bool,
 };
 
 export {

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -266,7 +266,7 @@ class GiftedChat extends React.Component {
   }
 
   onKeyboardWillShow(e) {
-    if (this.props.isPDMOpen) {
+    if (!this.props.enableKeyboardEvents) {
       return;
     }
 
@@ -287,7 +287,7 @@ class GiftedChat extends React.Component {
   }
 
   onKeyboardWillHide() {
-    if (this.props.isPDMOpen) {
+    if (!this.props.enableKeyboardEvents) {
       return;
     }
 
@@ -308,7 +308,7 @@ class GiftedChat extends React.Component {
   }
 
   onKeyboardDidShow(e) {
-    if (this.props.isPDMOpen) {
+    if (!this.props.enableKeyboardEvents) {
       return;
     }
 
@@ -319,7 +319,7 @@ class GiftedChat extends React.Component {
   }
 
   onKeyboardDidHide(e) {
-    if (this.props.isPDMOpen) {
+    if (!this.props.enableKeyboardEvents) {
       return;
     }
 
@@ -611,6 +611,7 @@ GiftedChat.defaultProps = {
   maxInputLength: null,
   forceGetKeyboardHeight: false,
   inverted: true,
+  enableKeyboardEvents: true,
 };
 
 GiftedChat.propTypes = {
@@ -661,7 +662,7 @@ GiftedChat.propTypes = {
   forceGetKeyboardHeight: PropTypes.bool,
   inverted: PropTypes.bool,
   textInputProps: PropTypes.object,
-  isPDMOpen: PropTypes.bool,
+  enableKeyboardEvents: PropTypes.bool,
 };
 
 export {

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -266,7 +266,7 @@ class GiftedChat extends React.Component {
   }
 
   onKeyboardWillShow(e) {
-    if (!this.props.enableKeyboardEvents) {
+    if (!this.props.shouldManageKeyboard) {
       return;
     }
 
@@ -287,7 +287,7 @@ class GiftedChat extends React.Component {
   }
 
   onKeyboardWillHide() {
-    if (!this.props.enableKeyboardEvents) {
+    if (!this.props.shouldManageKeyboard) {
       return;
     }
 
@@ -308,7 +308,7 @@ class GiftedChat extends React.Component {
   }
 
   onKeyboardDidShow(e) {
-    if (!this.props.enableKeyboardEvents) {
+    if (!this.props.shouldManageKeyboard) {
       return;
     }
 
@@ -319,7 +319,7 @@ class GiftedChat extends React.Component {
   }
 
   onKeyboardDidHide(e) {
-    if (!this.props.enableKeyboardEvents) {
+    if (!this.props.shouldManageKeyboard) {
       return;
     }
 
@@ -611,7 +611,7 @@ GiftedChat.defaultProps = {
   maxInputLength: null,
   forceGetKeyboardHeight: false,
   inverted: true,
-  enableKeyboardEvents: true,
+  shouldManageKeyboard: true,
 };
 
 GiftedChat.propTypes = {
@@ -662,7 +662,7 @@ GiftedChat.propTypes = {
   forceGetKeyboardHeight: PropTypes.bool,
   inverted: PropTypes.bool,
   textInputProps: PropTypes.object,
-  enableKeyboardEvents: PropTypes.bool,
+  shouldManageKeyboard: PropTypes.bool,
 };
 
 export {


### PR DESCRIPTION
When a use opens the PlayerDetailModal from within Chat and focuses the text input, the messages container should not avoid the keyboard in the background.